### PR TITLE
Extend keys list mapped in getEvent() method of calendar resource

### DIFF
--- a/lib/resources/calendar.js
+++ b/lib/resources/calendar.js
@@ -20,8 +20,10 @@ module.exports = class Calendar extends Resource {
           , "lesson"
           , "teacher"
           , "type"
+          , "class"
+          , "room"
           , "description"
-          , "date"
+          , "added"
         ]
       );
   }


### PR DESCRIPTION
@Mati365, zauważyłam, że obecnie szczegóły "eventa" w kalendarzu mają więcej pól. Wcześniej w ogóle nie widziałam (w zwracanych wynikach) opisu wydarzenia, a jako "date" mapował się numer sali. Stąd PR ze zaktualizowaną listą kluczy.