### PR TITLE
Fixed Teacher's absence getEvent

### DIFF
--- a/lib/resources/calendar.js
+++ b/lib/resources/calendar.js
@@ -9,23 +9,37 @@ module.exports = class Calendar extends Resource {
    * https://synergia.librus.pl/terminarz/szczegoly
    *
    * @param id  Event ID
+   * @param isAbsence Make it 'true' if the event is teacher's absence
    * @returns {Promise}
    */
-  getEvent(id) {
-    return this.api
-      ._tableMapper(
-          `terminarz/szczegoly/${id}`
-        , "table.decorated.small.center tbody"
-        , [ "date"
-          , "lesson"
-          , "teacher"
-          , "type"
-          , "class"
-          , "room"
-          , "description"
-          , "added"
-        ]
-      );
+  getEvent(id, isAbsence = false) {
+    if (isAbsence) {
+      return this.api
+        ._tableMapper(
+            `terminarz/szczegoly_wolne/${id}`
+          , "table.decorated.small.center tbody"
+          , [ "teacher"
+            , "range"
+            , "added"
+          ]
+        );
+    }
+    else {
+      return this.api
+        ._tableMapper(
+            `terminarz/szczegoly/${id}`
+          , "table.decorated.small.center tbody"
+          , [ "date"
+            , "lesson"
+            , "teacher"
+            , "type"
+            , "class"
+            , "room"
+            , "description"
+            , "added"
+          ]
+        );
+    }
   }
 
   /**


### PR DESCRIPTION
When you try to use calendar.getEvent function on teacher's absence event it will return empty data, because the teacher's absence has another url on librus than anothers. 

More specifically: Teacher's absence is using: 'terminarz/szczegoly_wolne/id' instead of 'terminarz/szczegoly/id' 