### PR TITLE
Added Day Property in getCalendar()

### DIFF
--- a/lib/resources/calendar.js
+++ b/lib/resources/calendar.js
@@ -49,6 +49,8 @@ module.exports = class Calendar extends Resource {
    * @returns {Promise}
    */
   getCalendar() {
+    const currentDate = new Date();
+
     let parser = ($, column) => {
       let table = $(column).next("table");
       if(!table)
@@ -58,6 +60,7 @@ module.exports = class Calendar extends Resource {
         let onclick = $(child).attr("onclick");
         return {
             id: parseInt(onclick && onclick.match(/\/(\d*)'$/)[1]) || -1
+          , day: `${currentDate.getFullYear()}-${currentDate.getMonth() + 1}-${$(column).text()}`
           , title: $(child).trim()
         };
       });


### PR DESCRIPTION
Added Day Property in returned object in function getCalendar (ex. 2021-09-14). Not every calendar event can be returned more precisely so I added a day property here, because it's can be useful on determine when event is current.