### PR TITLE
2FA zamiast Grant w URLu do uwierzytelnienia

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -107,7 +107,7 @@ class Librus {
               }})})
       .then(response => {
         return caller
-         .get("https://api.librus.pl/OAuth/Authorization/Grant?client_id=46")
+         .get("https://api.librus.pl/OAuth/Authorization/2FA?client_id=46")
          .then(response => {
             return this.cookie.getCookies(config.page_url);
           })


### PR DESCRIPTION
Tego lata przestało mi działać logowanie. I po trzech wieczorach debugowania doszedłem do tego, że zmieniono URL w procesie uwierzytelnienia. 

U mnie, w moim forku z tą zmianą działa, a bez tej zmiany nie działa: https://github.com/mccartney/librus-api/commit/e1e35b37ab69377873b93ff5fe3a22231ee5689b
Nie wiem na ile ta zmiana po ich stronie jest uniwersalna - teoretycznie może to być dla wybranych użytkowników, albo zależne od ustawień (?).