### PR TITLE
poprawka do cheerio

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -1,7 +1,7 @@
 "use strict";
 
 const requestprom = require("request-promise")
-    , cheerio = require("cheerio")
+    , cheerio = require("cheerio").default
     , _       = require("lodash")
     , request = require("request");
 


### PR DESCRIPTION
w wersji 2.8.1 przy uruchomieniu jest błąd
> Unhandled rejection TypeError: cheerio is not a function

podobny problem tutaj wayfair/dociql/issues/36
