### PR TITLE
Fix attachments support after migration to Axios

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -1,9 +1,7 @@
 "use strict";
 
-const requestprom = require("request-promise"),
-  cheerio = require("cheerio").default,
+const cheerio = require("cheerio").default,
   _ = require("lodash"),
-  request = require("request"),
   { wrapper } = require("axios-cookiejar-support"),
   { CookieJar } = require("tough-cookie"),
   axios = require("axios");
@@ -156,32 +154,32 @@ class Librus {
       : config.page_url + "/" + path;
 
     let options1 = {
-      jar: this.cookie,
-      gzip: true,
+      headers: {
+        "User-Agent":
+          "User-Agent:Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/47.0.2526.73 Safari/537.36",
+      },
+      responseType: 'stream',
+    };
+
+    let options2 = {
+      maxRedirects: 0,
+      simple: false,
+      validateStatus: null,
+      resolveWithFullResponse: true,
       headers: {
         "User-Agent":
           "User-Agent:Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/47.0.2526.73 Safari/537.36",
       },
     };
 
-    let options2 = _.extend(
-      {
-        uri: target,
-        followRedirect: false,
-        simple: false,
-        resolveWithFullResponse: true,
-      },
-      options1
-    );
-
     /** Make request */
-    return requestprom["get"](options2).then((response) => {
+    return this.caller.get(target, options2).then((response) => {
       let redirect = response.headers.location,
         url = null;
       // For some reason files may be served in two totally different ways...
       if (redirect.includes("GetFile")) {
         url = redirect + "/get";
-        return request.get(url, options1);
+        return this.caller.get(url, options1).then((response) => { return response.data });
       } else {
         const key = new URL(redirect).searchParams.get("singleUseKey");
         return this._waitForFileReady(key, options1, redirect);
@@ -198,20 +196,21 @@ class Librus {
    */
   _waitForFileReady(key, options, redirect) {
     const checkKey = "https://sandbox.librus.pl/index.php?action=CSCheckKey";
-    return requestprom["post"](
-      _.extend(
-        {
-          url: checkKey,
-          form: {
-            singleUseKey: key,
-          },
+    return this.caller.post(
+      {
+        headers: {
+          "User-Agent":
+            "User-Agent:Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/47.0.2526.73 Safari/537.36",
         },
-        options
-      )
+        url: checkKey,
+        form: {
+          singleUseKey: key,
+        },
+      }
     ).then((response) => {
-      if (response.includes("ready")) {
+      if (response.data.includes("ready")) {
         let url = redirect.replace("CSTryToDownload", "CSDownload");
-        return request.get(url, options);
+        return this.caller.get(url, options).then((response) => { return response.data });
       } else {
         return this._waitForFileReady(key, options, redirect);
       }


### PR DESCRIPTION
Przy okazji, w jaki sposób (i czy w ogóle) jest obsłużone stronicowanie w skrzynkach? Nie mogę znaleźć tego w kodzie, w README jest wspomniane:

```
// List all e-mails in folder(5) in page(2)
client.inbox.listInbox(5).then((data) => {});
```

ale ten komentarz jest chyba nieaktualny.