### PR TITLE
Dodatkowe informacje do ocen

### DIFF
--- a/lib/resources/info.js
+++ b/lib/resources/info.js
@@ -205,6 +205,7 @@ module.exports = class Info extends Resource {
                   $(element).find("a").attr("href").split("/").length - 1
                 ]
               ),
+              info: $(element).find("a").attr("title").replace(/<\s*br\s*\/?\s*>/g, "\n"),
               value: $(element).trim(),
             };
           }


### PR DESCRIPTION
W ocenach dostępne są dodatkowe informacje, ważne szczególnie w przypadku ocen, które nie mają ID i w związku z tym nie da się nic więcej dla nich wyciągnąć. Nowy obiekt wygląda tak:

```
{
  id: 2219322,
  info: 'Kategoria: kartkówka zwroty\n' +
    'Data: 2023-10-03 (wt.)\n' +
    'Nauczyciel: xxx\n' +
    'Licz do średniej: tak\n' +
    'Waga: 1\n' +
    'Dodał: xxx\n',
  value: '6'
}
```