### PR TITLE
fix getTimetable

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -1,12 +1,13 @@
 "use strict";
 
-const cheerio = require("cheerio").default,
+const cheerio = require("cheerio"),
   _ = require("lodash"),
   { wrapper } = require("axios-cookiejar-support"),
   { CookieJar } = require("tough-cookie"),
   axios = require("axios");
 
 const config = require("./config.js");
+const { makeBoolean } = require("./tools.js");
 
 /** Export class */
 class Librus {
@@ -140,7 +141,7 @@ class Librus {
         url: target,
         data,
       })
-      .then(({ data }) => cheerio.load(data));
+      .then(({ data }) => Librus._loadDocument(data));
   }
 
   /**
@@ -218,6 +219,24 @@ class Librus {
   }
 
   /**
+   * Creates querying function and adds utility functions
+   * @param {string} Input HTML
+   * @returns {cheerio.CheerioAPI} document  
+   */
+  static _loadDocument(document) {
+    const $ =  cheerio.load(document)
+    $.prototype.trim = function () {
+      return this.text().trim()
+    };
+
+    $.prototype.makeBoolean = function () {
+      return makeBoolean(this.trim())
+    };
+
+    return $
+  }
+
+  /**
    * Map array values to array using parser
    * @param $       Document
    * @param parser  Parser callback
@@ -260,8 +279,8 @@ class Librus {
   static mapTableValues(table, keys) {
     return _.zipObject(
       keys,
-      _.map(cheerio(table).find("tr td:nth-child(2)"), (row) => {
-        return cheerio(row).trim();
+      _.map(cheerio.default(table).find("tr td:nth-child(2)"), (row) => {
+        return cheerio.default(row).text().trim();
       })
     );
   }
@@ -275,8 +294,8 @@ class Librus {
     return _.chain()
       .map(cheerio(table).find("tr"), (row) => {
         return [
-          cheerio(row).children(0).trim(),
-          cheerio(row).children(1).trim(),
+          cheerio.default(row).children(0).text().trim(),
+          cheerio.default(row).children(1).text().trim(),
         ];
       })
       .zipObject()

--- a/lib/resources/calendar.js
+++ b/lib/resources/calendar.js
@@ -164,8 +164,8 @@ module.exports = class Calendar extends Resource {
           "table.decorated.plan-lekcji tr:nth-child(odd)"
         );
       _.each(rows, (value) => {
-        for (let i = 0; i < value.list.length; ++i) {
-          let key = days[i];
+        for (let i = 1; i < value.list.length; ++i) {
+          let key = days[i - 1];
           (table[key] = table[key] || []).push(value.list[i]);
         }
       });

--- a/lib/resources/calendar.js
+++ b/lib/resources/calendar.js
@@ -1,5 +1,6 @@
 "use strict";
 const _ = require("lodash");
+const FormData = require('form-data');
 const Resource = require("../tools.js").Resource,
   Librus = require("../api");
 
@@ -178,7 +179,7 @@ module.exports = class Calendar extends Resource {
 
     /** API call */
     let formData = new FormData()
-    formData.set("tydzien", `${from}_${to}`)
+    formData.append("tydzien", `${from}_${to}`)
     return this.api._request("post", "przegladaj_plan_lekcji", formData)
     .then(tableMapper);
   }

--- a/lib/resources/calendar.js
+++ b/lib/resources/calendar.js
@@ -177,9 +177,9 @@ module.exports = class Calendar extends Resource {
     };
 
     /** API call */
-    return this.api._request("post", "przegladaj_plan_lekcji", {
-      form: { tydzien: from && `${from}_${to}` },
-    })
+    let formData = new FormData()
+    formData.set("tydzien", `${from}_${to}`)
+    return this.api._request("post", "przegladaj_plan_lekcji", formData)
     .then(tableMapper);
   }
 };

--- a/lib/resources/calendar.js
+++ b/lib/resources/calendar.js
@@ -161,7 +161,7 @@ module.exports = class Calendar extends Resource {
         rows = Librus.arrayMapper(
           $,
           parser,
-          "table.decorated.plan-lekcji tr:nth-child(even)"
+          "table.decorated.plan-lekcji tr:nth-child(odd)"
         );
       _.each(rows, (value) => {
         for (let i = 0; i < value.list.length; ++i) {
@@ -177,10 +177,9 @@ module.exports = class Calendar extends Resource {
     };
 
     /** API call */
-    return this.api.caller
-      .post("przegladaj_plan_lekcji", {
-        form: { tydzien: from && `${from}_${to}` },
-      })
-      .then(tableMapper);
+    return this.api._request("post", "przegladaj_plan_lekcji", {
+      form: { tydzien: from && `${from}_${to}` },
+    })
+    .then(tableMapper);
   }
 };

--- a/lib/tools.js
+++ b/lib/tools.js
@@ -11,16 +11,6 @@ function makeBoolean(status) {
   return status.toLowerCase() === "tak";
 }
 
-/** Get already trimmed text */
-Object.getPrototypeOf(cheerio).trim = function () {
-  return this.text().trim();
-};
-
-/** Make boolean from title */
-Object.getPrototypeOf(cheerio).makeBoolean = function () {
-  return makeBoolean(this.trim());
-};
-
 /**
  * API resource
  * @type {Resource}


### PR DESCRIPTION
call directly on axios (without baseURL set) caused call to `http://localhost/przegladaj_plan_lekcji`
on top of that callback used axios response instead of object create by cheerio

additionally odd rows supposed to be used

i've also removed very dangerous attempt to extend `cheerio`. In fact this extension modified Object prototype, which affected many others. It actually broke Axios calls in project I've used this lib in.