### PR TITLE
Fix cheerio usage; make file download work

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -197,19 +197,17 @@ class Librus {
    */
   _waitForFileReady(key, options, redirect) {
     const checkKey = "https://sandbox.librus.pl/index.php?action=CSCheckKey";
-    return this.caller.post(
+    return this.caller.postForm(checkKey, {
+        singleUseKey: key,
+      },
       {
         headers: {
           "User-Agent":
             "User-Agent:Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/47.0.2526.73 Safari/537.36",
         },
-        url: checkKey,
-        form: {
-          singleUseKey: key,
-        },
       }
     ).then((response) => {
-      if (response.data.includes("ready")) {
+      if (response.data.status === "ready" || (typeof response.data.inclues === "function" && response.data.includes("ready"))) {
         let url = redirect.replace("CSTryToDownload", "CSDownload");
         return this.caller.get(url, options).then((response) => { return response.data });
       } else {

--- a/lib/api.js
+++ b/lib/api.js
@@ -277,8 +277,8 @@ class Librus {
   static mapTableValues(table, keys) {
     return _.zipObject(
       keys,
-      _.map(cheerio.default(table).find("tr td:nth-child(2)"), (row) => {
-        return cheerio.default(row).text().trim();
+      _.map(table.find("tr td:nth-child(2)"), (row) => {
+        return Librus._loadDocument(row).text().trim();
       })
     );
   }


### PR DESCRIPTION
Przestało u mnie działać, więc naprawiam.

Jeśli chodzi o ściąganie pliku, to nie jestem pewien czy to kiedykolwiek działało. Librus wystawia pliki na dwa sposoby, nie wiem od czego to zależy. Albo teraz zmienili jeden z tych sposobów, albo ten sposób nigdy nie działał i akurat wszystkie pliki były wystawiane tym innym. Za drugą teorią przemawia fakt, że musiałem też zmienić wywołanie samego Axiosa, albo też zmienili (chociaż wersja Axiosa jest zablokowana od dawna), albo zawsze było nieprawidłowe. Jest jeszcze taka opcja, że dla części plików zwracają body w nowym formacie, dlatego zostawiłem też obsługę starego formatu jakby co.

Co do cheerio, chyba pozmieniali parę rzeczy w https://github.com/cheeriojs/cheerio/releases/tag/v1.0.0.