### PR TITLE
fix for calendar.getEvent failing to return event data

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -67,7 +67,7 @@ class Librus {
         /** add parser callback */
         .concat([
           ($, table) => {
-            return Librus.mapTableValues(table, keys);
+            return Librus.mapTableValues($, table, keys);
           },
         ])
         .value();
@@ -274,10 +274,10 @@ class Librus {
    * mapTableValues(dom, ["id", "name"])
    * // => { id: 23, name: "test" }
    */
-  static mapTableValues(table, keys) {
+  static mapTableValues($, table, keys) {
     return _.zipObject(
       keys,
-      _.map(table.find("tr td:nth-child(2)"), (row) => {
+      _.map($(table).find("tr td:nth-child(2)"), (row) => {
         return Librus._loadDocument(row).text().trim();
       })
     );


### PR DESCRIPTION
This PR should fix the bug mentioned here: https://github.com/Mati365/librus-api/issues/24