### PR TITLE
Fix calendar month

### DIFF
--- a/lib/resources/calendar.js
+++ b/lib/resources/calendar.js
@@ -68,7 +68,7 @@ module.exports = class Calendar extends Resource {
       }
     };
     let formData = new FormData()
-    formData.append("miesiac", month)
+    formData.append("miesiac", currentDate.getMonth())
     formData.append("rok", currentDate.getFullYear())
     return this.api._mapper(
       "terminarz",


### PR DESCRIPTION
Siema.
Obecnie próba dostania terminarza bez pierwszego argumentu (miesiąca) wywala błąd.
```js
client.calendar.getCalendar().then((data) => {});
```
```
/home/oogooro/node/librus-echelon/node_modules/form-data/lib/form_data.js:227
  } else if (options.filename || value.name || value.path) {
                                       ^
TypeError: Cannot read properties of undefined (reading 'name')
    at FormData._getContentDisposition (/home/oogooro/node/librus-echelon/node_modules/form-data/lib/form_data.js:227:40)
    at FormData._multiPartHeader (/home/oogooro/node/librus-echelon/node_modules/form-data/lib/form_data.js:178:33)
    at FormData.append (/home/oogooro/node/librus-echelon/node_modules/form-data/lib/form_data.js:71:21)
    at Calendar.getCalendar (/home/oogooro/node/librus-echelon/node_modules/librus-api/lib/resources/calendar.js:72:14)
    at /home/oogooro/node/librus-echelon/src/index.ts:70:69
    at processTicksAndRejections (node:internal/process/task_queues:95:5)
```
Aby nie wywalało trzeba:
```js
client.calendar.getCalendar(12).then((data) => {});
```
Nie wydaje mi się, żeby to było zamierzone zachowanie więc ten PR to naprawia, aby dało się wywołać funkcję bez żadnego parametru tak jak to jest w README.
Testowane. Śmiga.