### PR TITLE
fix: fixed authorization process

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -119,33 +119,27 @@ class Librus {
     }
 
     let caller = this.caller;
-    return caller
-      .get("https://synergia.librus.pl/loguj/portalRodzina", {
-        headers: {
-          Referer: "https://portal.librus.pl/"
-        }
-      })
-      .then(() => caller.get("https://api.librus.pl/OAuth/Authorization?client_id=46&response_type=code&scope=mydata"))
-      .then(() => {
-        return caller.postForm(
-          "https://api.librus.pl/OAuth/Authorization?client_id=46",
-          {
-            action: "login",
-            login: login,
-            pass: pass,
-          }
-        );
-      })
-      .then(() => caller.get("https://api.librus.pl/OAuth/Authorization/2FA?client_id=46"))
-      .then(() =>
-        caller.postForm("https://api.librus.pl/OAuth/Authorization/2FA?client_id=46", {
-          action: "requiredActions",
-          skip: "true",
-        })
-      )
-      .then(() => caller.get("https://api.librus.pl/OAuth/Authorization/Grant?client_id=46"))
-      .then(() => this.cookie.getCookies(config.page_url))
-      .catch(console.error);
+
+    // Step 1: portalRodzina redirects to the OAuth authorization page
+    const r1 = await caller.get("https://synergia.librus.pl/loguj/portalRodzina", {
+      headers: { Referer: "https://portal.librus.pl/" }
+    });
+
+    // Step 2: POST credentials to the page we landed on after the redirect
+    const loginUrl = r1.request?.res?.responseUrl || "https://api.librus.pl/OAuth/Authorization?client_id=46";
+    const loginResponse = await caller.postForm(loginUrl, {
+      action: "login",
+      login: login,
+      pass: pass,
+    });
+
+    // Step 3: GET the 2FA/next URL returned in the JSON response.
+    // The server skips 2FA and redirects to synergia.librus.pl with the OAuth code,
+    // which sets the session cookies automatically.
+    const nextUrl = "https://api.librus.pl" + loginResponse.data.goTo;
+    await caller.get(nextUrl);
+
+    return this.cookie.getCookies(config.page_url);
   }
 
   /**


### PR DESCRIPTION
**Redundant second OAuth GET**
After portalRodzina already redirected to the OAuth auth page, a second GET to the same page created a new OAuth session, overwriting the one just created. Then the 2FA POST and Grant GET ran after the OAuth code was already issued, triggering invalid_request errors