### PR TITLE
uwzględnianie ocen poprawianych i poprawionych

### DIFF
--- a/lib/resources/info.js
+++ b/lib/resources/info.js
@@ -196,17 +196,21 @@ module.exports = class Info extends Resource {
        */
       let semester = (startColumn) => {
         let grades = _.map(
-          $(children[startColumn]).children("span.grade-box"),
+          $(children[startColumn]).find("span.grade-box"),
           (element) => {
-            const color = $(element).css("background-color");
+            const link = $(element).find("a").first();
+            const href = link.attr("href") || "";
+            const idRaw = href.split("/")[href.split("/").length - 1];
+            const title = (link.attr("title") || "").replace(
+              /<\s*br\s*\/?\s*>/g,
+              "\n"
+            );
+            const value = link.text().trim().replace(/\*+$/, "").trim();
+
             return {
-              id: parseInt(
-                $(element).find("a").attr("href").split("/")[
-                  $(element).find("a").attr("href").split("/").length - 1
-                ]
-              ),
-              info: $(element).find("a").attr("title").replace(/<\s*br\s*\/?\s*>/g, "\n"),
-              value: $(element).trim(),
+              id: parseInt(idRaw),
+              info: title,
+              value: value,
             };
           }
         );


### PR DESCRIPTION
bug: parser gubił oceny w [...] (poprawiane)
fix: children("span.grade-box") -> find("span.grade-box"), poprawiony odczyt value i id
przykład: przypadek „2 z angielskiego” z Poprawa oceny.