### PR TITLE
Fix current Synergia data parsing

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -5,8 +5,8 @@ config.page_url = "https://synergia.librus.pl";
 
 /** Folder indexes */
 config.folder = {
-  SENT: 5,
-  RECEIVED: 6,
+  RECEIVED: 5,
+  SENT: 6,
 };
 
 /** Exports */

--- a/lib/resources/absence.js
+++ b/lib/resources/absence.js
@@ -50,7 +50,7 @@ module.exports = class Absence extends tools.Resource {
             )
             .then((secData) => {
               return _.assign(secData, {
-                trip: tools.makeBoolean(data.trip),
+                trip: tools.makeBoolean(secData.trip),
               });
             });
         } else {

--- a/lib/resources/calendar.js
+++ b/lib/resources/calendar.js
@@ -24,8 +24,8 @@ module.exports = class Calendar extends Resource {
       return this.api._tableMapper(
         `terminarz/szczegoly/${id}`,
         "table.decorated.medium.center tbody",
-        {'Data': 'date', 'Nr lekcji': 'lesson', 'Nauczyciel': 'teacher', 'Rodzaj': 'type', 'Przedmiot': 'lesson', 'Sala': 'room', 'Opis': 'description', 'Data dodania': 'added', 'Przedział czasu': 'timespan'}
-      );
+        {'Data': 'date', 'Nr lekcji': 'lessonNumber', 'Nauczyciel': 'teacher', 'Rodzaj': 'type', 'Przedmiot': 'subject', 'Sala': 'room', 'Opis': 'description', 'Data dodania': 'added', 'Przedział czasu': 'timespan'}
+      ).then((event) => event && Object.assign({ lesson: event.subject }, event));
     }
   }
 
@@ -53,7 +53,7 @@ module.exports = class Calendar extends Resource {
           let onclick = $(child).attr("onclick");
           return {
             id: parseInt(onclick && onclick.match(/\/(\d*)'$/)[1]) || -1,
-            day: `${currentDate.getFullYear()}-${currentDate.getMonth() + 1}-${$(day).text()}`,
+            day: `${currentDate.getFullYear()}-${String(currentDate.getMonth() + 1).padStart(2, "0")}-${String($(day).text()).padStart(2, "0")}`,
             title: $(child).trim(),
           };
         });
@@ -94,12 +94,15 @@ module.exports = class Calendar extends Resource {
     if (!from || !to) {
       const today = new Date();
       const monday = new Date(today);
-      monday.setDate(today.getDate() - today.getDay() + 1);
+      const daysSinceMonday = (today.getDay() + 6) % 7;
+      monday.setDate(today.getDate() - daysSinceMonday);
       const sunday = new Date(monday);
       sunday.setDate(monday.getDate() + 6);
-      
-      from = monday.toISOString().split('T')[0];
-      to = sunday.toISOString().split('T')[0];
+
+      const formatDate = (date) =>
+        `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, "0")}-${String(date.getDate()).padStart(2, "0")}`;
+      from = formatDate(monday);
+      to = formatDate(sunday);
     }
 
     /** Parser */

--- a/lib/resources/info.js
+++ b/lib/resources/info.js
@@ -161,15 +161,16 @@ module.exports = class Info extends Resource {
   }
   /**
    * Get lucky number
-   * https://synergia.librus.pl/uczen/index
+   * https://synergia.librus.pl/uczen_index
    *
    * @returns {Promise}
    */
   getLuckyNumber() {
     let parser = ($, element) => {
-      return parseInt(element.children[1].children[0].data);
+      const match = $(element).text().match(/\d+/);
+      return match ? parseInt(match[0], 10) : null;
     };
-    return this.api._singleMapper("uczen/index", ".luckyNumber", parser);
+    return this.api._singleMapper("uczen_index", ".luckyNumber", parser);
   }
   /**
    * Get grades list


### PR DESCRIPTION
## Summary

- fix `getLuckyNumber()` to use the working `uczen_index` dashboard route
- keep event lesson number and subject in separate fields while preserving the existing `lesson` subject alias
- convert `trip` from the correctly parsed seven-field absence fallback
- keep the default timetable on the current week when called on Sunday
- return zero-padded calendar dates
- correct the `RECEIVED` / `SENT` folder constants to match the current Synergia UI

Related historical reports: #30, #55.

## Compatibility

`getEvent()` now exposes `lessonNumber` and `subject`. The existing `lesson` property remains available and contains the same subject value, so current consumers do not need to migrate immediately.

## Verification

- regression fixtures for all six cases failed before the changes and passed after them
- `node --check` passed for every changed JavaScript file
- live parent-account checks passed for authorization, lucky number, calendar, event details and timetable
- no account data, credentials or fixture files are included in this PR
