### PR TITLE
Bound attachment downloads and HTTP waits

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -13,9 +13,18 @@ class Librus {
   /**
    * Create Librus API client
    * @param cookies  Array of cookies
+   * @param options  Request and attachment polling options
    */
-  constructor(cookies) {
+  constructor(cookies, options = {}) {
     this.cookie = new CookieJar();
+    this.options = Object.assign(
+      {
+        requestTimeout: 30000,
+        filePollAttempts: 10,
+        filePollDelay: 500,
+      },
+      options
+    );
 
     /**
      * Get cookies from array
@@ -24,7 +33,7 @@ class Librus {
     this.cookie.setCookie("TestCookie=1;", config.page_url);
 
     // Initialize caller asynchronously
-    this._initializeCaller();
+    this._callerReady = this._initializeCaller();
     this._initializeMappers();
     this._loadModules(["inbox", "homework", "absence", "calendar", "info"]);
   }
@@ -35,10 +44,17 @@ class Librus {
    */
   async _initializeCaller() {
     const { wrapper } = await import("axios-cookiejar-support");
+    const timeoutOption = Number(this.options?.requestTimeout);
+    const timeout = Number.isFinite(timeoutOption) && timeoutOption > 0
+      ? Math.min(timeoutOption, 120000)
+      : 30000;
     this.caller = wrapper(
       axios.create({
         jar: this.cookie,
         withCredentials: true,
+        timeout,
+        maxContentLength: 10 * 1024 * 1024,
+        maxBodyLength: 1024 * 1024,
         headers: {
           "User-Agent":
             "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36",
@@ -115,7 +131,7 @@ class Librus {
   async authorize(login, pass) {
     // Ensure caller is initialized
     if (!this.caller) {
-      await this._initializeCaller();
+      await (this._callerReady || this._initializeCaller());
     }
 
     let caller = this.caller;
@@ -171,9 +187,7 @@ class Librus {
    * @returns {String}
    */
   _getFile(path) {
-    let target = path.startsWith("https://")
-      ? path
-      : config.page_url + "/" + path;
+    const target = this._safeLibrusUrl(path, config.page_url + "/");
 
     let options1 = {
       headers: {
@@ -196,17 +210,41 @@ class Librus {
 
     /** Make request */
     return this.caller.get(target, options2).then((response) => {
-      let redirect = response.headers.location,
-        url = null;
+      const location = response.headers.location;
+      if (!location) {
+        throw new Error("Attachment response did not contain a redirect location.");
+      }
+      const redirect = this._safeLibrusUrl(location, target);
       // For some reason files may be served in two totally different ways...
       if (redirect.includes("GetFile")) {
-        url = redirect + "/get";
+        const url = redirect.replace(/\/?$/, "/get");
         return this.caller.get(url, options1).then((response) => { return response.data });
       } else {
         const key = new URL(redirect).searchParams.get("singleUseKey");
+        if (!key) throw new Error("Attachment redirect did not contain a single-use key.");
         return this._waitForFileReady(key, options1, redirect);
       }
     });
+  }
+
+  _safeLibrusUrl(value, base) {
+    const url = new URL(value, base);
+    const librusHost = url.hostname === "librus.pl" || url.hostname.endsWith(".librus.pl");
+    const defaultPort = !url.port || url.port === "443";
+    if (
+      url.protocol !== "https:" ||
+      !librusHost ||
+      !defaultPort ||
+      url.username ||
+      url.password
+    ) {
+      throw new Error("Attachment URL must use HTTPS on a librus.pl host.");
+    }
+    return url.toString();
+  }
+
+  _sleep(delay) {
+    return new Promise((resolve) => setTimeout(resolve, delay));
   }
 
   /**
@@ -216,25 +254,39 @@ class Librus {
    * @param redirect   Download attempt URL
    * @returns {String}
    */
-  _waitForFileReady(key, options, redirect) {
+  async _waitForFileReady(key, options, redirect) {
     const checkKey = "https://sandbox.librus.pl/index.php?action=CSCheckKey";
-    return this.caller.postForm(checkKey, {
-        singleUseKey: key,
-      },
-      {
+    const attemptsOption = Number(this.options?.filePollAttempts);
+    const delayOption = Number(this.options?.filePollDelay);
+    const attempts = Number.isFinite(attemptsOption) && attemptsOption > 0
+      ? Math.min(100, Math.floor(attemptsOption))
+      : 10;
+    const delay = Number.isFinite(delayOption) && delayOption >= 0
+      ? Math.min(60000, delayOption)
+      : 500;
+    for (let attempt = 1; attempt <= attempts; attempt += 1) {
+      const response = await this.caller.postForm(
+        checkKey,
+        { singleUseKey: key },
+        {
         headers: {
           "User-Agent":
             "User-Agent:Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/47.0.2526.73 Safari/537.36",
         },
+        }
+      );
+      const data = response.data;
+      const ready = data?.status === "ready" || (typeof data === "string" && data.includes("ready"));
+      if (ready) {
+        const url = this._safeLibrusUrl(
+          redirect.replace("CSTryToDownload", "CSDownload")
+        );
+        const download = await this.caller.get(url, options);
+        return download.data;
       }
-    ).then((response) => {
-      if (response.data.status === "ready" || (typeof response.data.inclues === "function" && response.data.includes("ready"))) {
-        let url = redirect.replace("CSTryToDownload", "CSDownload");
-        return this.caller.get(url, options).then((response) => { return response.data });
-      } else {
-        return this._waitForFileReady(key, options, redirect);
-      }
-    });
+      if (attempt < attempts) await this._sleep(delay);
+    }
+    throw new Error(`Attachment was not ready after ${attempts} attempts.`);
   }
 
   /**

--- a/lib/api.js
+++ b/lib/api.js
@@ -142,7 +142,10 @@ class Librus {
     });
 
     // Step 2: POST credentials to the page we landed on after the redirect
-    const loginUrl = r1.request?.res?.responseUrl || "https://api.librus.pl/OAuth/Authorization?client_id=46";
+    const loginUrl = this._safeAuthorizationUrl(
+      r1.request?.res?.responseUrl ||
+        "https://api.librus.pl/OAuth/Authorization?client_id=46"
+    );
     const loginResponse = await caller.postForm(loginUrl, {
       action: "login",
       login: login,
@@ -152,7 +155,7 @@ class Librus {
     // Step 3: GET the 2FA/next URL returned in the JSON response.
     // The server skips 2FA and redirects to synergia.librus.pl with the OAuth code,
     // which sets the session cookies automatically.
-    const nextUrl = "https://api.librus.pl" + loginResponse.data.goTo;
+    const nextUrl = this._safeAuthorizationUrl(loginResponse.data?.goTo);
     await caller.get(nextUrl);
 
     return this.cookie.getCookies(config.page_url);
@@ -195,6 +198,8 @@ class Librus {
           "User-Agent:Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/47.0.2526.73 Safari/537.36",
       },
       responseType: 'stream',
+      maxRedirects: 0,
+      validateStatus: (status) => status >= 200 && status < 300,
     };
 
     let options2 = {
@@ -240,6 +245,19 @@ class Librus {
     ) {
       throw new Error("Attachment URL must use HTTPS on a librus.pl host.");
     }
+    return url.toString();
+  }
+
+  _safeAuthorizationUrl(value) {
+    const url = new URL(value, "https://api.librus.pl");
+    const valid =
+      url.protocol === "https:" &&
+      url.hostname === "api.librus.pl" &&
+      (!url.port || url.port === "443") &&
+      !url.username &&
+      !url.password &&
+      url.pathname.startsWith("/OAuth/Authorization");
+    if (!valid) throw new Error("Unexpected Librus authorization URL.");
     return url.toString();
   }
 


### PR DESCRIPTION
## Summary

- give Axios requests a finite default timeout and bounded body/response sizes
- reuse the in-flight caller initialization instead of starting a second one during authorization
- validate OAuth destinations before posting credentials
- reject attachment URLs outside HTTPS `librus.pl` hosts, non-default ports and credential-bearing URLs
- disable implicit redirects on final attachment downloads
- handle missing redirect locations and single-use keys with explicit errors
- replace unbounded recursive attachment polling with a bounded loop and delay
- fix string `ready` responses, which were ignored because of the `inclues` typo

## Configuration

The existing constructor remains compatible. Optional network settings can be passed as the second argument:

```js
new Librus(undefined, {
  requestTimeout: 30000,
  filePollAttempts: 10,
  filePollDelay: 500,
});
```

Values are bounded to prevent accidental infinite waits.

## Verification

- pre-fix fixtures reproduced missing timeout, ignored string responses and unbounded polling
- post-fix fixtures covered ready, never-ready, missing-location, rejected-host and rejected-OAuth-target cases
- `node --check lib/api.js`
- live authorization succeeded with the new 30-second caller timeout
- no attachment was downloaded and no account data or credentials are included
