### PR TITLE
Fix inbox HTTP requests

### DIFF
--- a/lib/resources/inbox.js
+++ b/lib/resources/inbox.js
@@ -21,9 +21,9 @@ module.exports = class Inbox extends Resource {
    * @private
    */
   static _getConfirmMessage($) {
-    let message = $(".green.container").trim();
-    if (!message.length) return Promise.reject();
-    else return message;
+    const message = $(".green.container").text().trim();
+    if (!message.length) return Promise.reject(new Error("Confirmation message not found"));
+    return message;
   }
 
   /**
@@ -99,15 +99,13 @@ module.exports = class Inbox extends Resource {
    */
   removeMessage(messageId) {
     return this.api.caller
-      .post("wiadomosci", {
-        form: {
-          tak: "Tak",
-          id: 1,
-          Wid: messageId,
-          poprzednia: 6,
-        },
+      .postForm(`${baseUrl}/wiadomosci`, {
+        tak: "Tak",
+        id: 1,
+        Wid: messageId,
+        poprzednia: 6,
       })
-      .then(Inbox._getConfirmMessage);
+      .then((response) => Inbox._getConfirmMessage(cheerio.load(response.data)));
   }
 
   /**
@@ -248,7 +246,6 @@ module.exports = class Inbox extends Resource {
           const cookieHeader = `DZIENNIKSID=${dzienniksid.value}; SDZIENNIKSID=${sdzienniksid.value}`;
 
           // Make requests for all recipient types
-          const axios = require("axios");
           const FormData = require("form-data");
 
           const requests = recipientTypes.map((recipientType) => {
@@ -259,7 +256,7 @@ module.exports = class Inbox extends Resource {
             formData.append("czyWirtualneKlasy", isVirtualClasses.toString());
             formData.append("idGrupy", groupId.toString());
 
-            return axios
+            return this.api.caller
               .post(`${baseUrl}/getRecipients`, formData, {
                 headers: {
                   "X-Requested-With": "XMLHttpRequest",
@@ -310,7 +307,7 @@ module.exports = class Inbox extends Resource {
               formData.append("klasa_opiekunowie", classId.toString());
               formData.append("klasa_rodzice", classId.toString());
 
-              return axios
+              return this.api.caller
                 .post(`${baseUrl}/getRecipients`, formData, {
                   headers: {
                     "X-Requested-With": "XMLHttpRequest",


### PR DESCRIPTION
## Summary

- submit message deletion as form data to the absolute Synergia URL
- parse the Axios response before reading the confirmation message
- return a useful error when the confirmation element is missing
- reuse the configured cookie-aware API caller for recipient requests instead of the global Axios client

Fixes #66.

Reusing `this.api.caller` keeps recipient requests on the same cookie jar and allows caller-level timeout and transport settings to apply consistently.

## Verification

- pre-fix fixtures reproduced the relative-URL deletion failure and global-Axios recipient requests
- post-fix fixtures verified the exact deletion URL/form and all recipient request groups
- `node --check lib/resources/inbox.js`
- live authorization and recipient listing succeeded through the configured caller
- deletion was not executed against a live account
- no account data, credentials or fixture files are included
